### PR TITLE
Omar net7updates

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,7 +17,7 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceFolder}/bin/Debug/net6.0/<project-name.dll>",
+            "program": "${workspaceFolder}/bin/Debug/net7.0/<project-name.dll>",
             "args": [],
             "cwd": "${workspaceFolder}",
             "stopAtEntry": false,

--- a/chapter02/consumer/consumerService.cs
+++ b/chapter02/consumer/consumerService.cs
@@ -26,8 +26,17 @@ namespace consumer
             while (!stoppingToken.IsCancellationRequested)
             {
                 consumer.Subscribe(topicName);
-                var result = consumer.Consume(stoppingToken);
-                await new MessageReceivedEventHandler().Handle(result);
+                try
+                {
+                    Console.WriteLine($"Trying to consume events on topic '{topicName}'...");
+                    var result = consumer.Consume(stoppingToken);
+                    await new MessageReceivedEventHandler().Handle(result);
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Failed to consume events on topic '{topicName}': {ex.Message}");
+                    Thread.Sleep(10000);
+                }
             }
         }
     }

--- a/chapter06/consumer/Dockerfile
+++ b/chapter06/consumer/Dockerfile
@@ -1,6 +1,6 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/runtime:6.0 AS base
+FROM mcr.microsoft.com/dotnet/runtime:7.0 AS base
 WORKDIR /app
 
 # <add commands here to modify both the debug and release container image>
@@ -9,7 +9,7 @@ RUN echo "This is my base image" > /tmp/image_type
 FROM base as mydebug
 RUN echo "This is my debug image" > /tmp/image_type
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 WORKDIR /src
 COPY ["consumer/consumer.csproj", "consumer/"]
 RUN dotnet restore "consumer/consumer.csproj"

--- a/chapter06/consumer/consumerService.cs
+++ b/chapter06/consumer/consumerService.cs
@@ -26,8 +26,17 @@ namespace consumer
             while (!stoppingToken.IsCancellationRequested)
             {
                 consumer.Subscribe(topicName);
-                var result = consumer.Consume(stoppingToken);
-                await new MessageReceivedEventHandler().Handle(result);
+                try
+                {
+                    Console.WriteLine($"Trying to consume events on topic '{topicName}'...");
+                    var result = consumer.Consume(stoppingToken);
+                    await new MessageReceivedEventHandler().Handle(result);
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Failed to consume events on topic '{topicName}': {ex.Message}");
+                    Thread.Sleep(10000);
+                }
             }
         }
     }

--- a/chapter06/producer/Dockerfile
+++ b/chapter06/producer/Dockerfile
@@ -1,6 +1,6 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
@@ -10,7 +10,7 @@ RUN echo "This is my base image" > /tmp/image_type
 FROM base as mydebug
 RUN echo "This is my debug image" > /tmp/image_type
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 WORKDIR /src
 COPY ["producer/producer.csproj", "producer/"]
 RUN dotnet restore "producer/producer.csproj"

--- a/chapter07/consumer/Dockerfile
+++ b/chapter07/consumer/Dockerfile
@@ -1,6 +1,6 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/runtime:6.0 AS base
+FROM mcr.microsoft.com/dotnet/runtime:7.0 AS base
 WORKDIR /app
 
 # <add commands here to modify both the debug and release container image>
@@ -9,7 +9,7 @@ RUN echo "This is my base image" > /tmp/image_type
 FROM base as mydebug
 RUN echo "This is my debug image" > /tmp/image_type
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 WORKDIR /src
 COPY ["consumer/consumer.csproj", "consumer/"]
 RUN dotnet restore "consumer/consumer.csproj"

--- a/chapter07/consumer/consumerService.cs
+++ b/chapter07/consumer/consumerService.cs
@@ -31,8 +31,19 @@ namespace consumer
             while (!stoppingToken.IsCancellationRequested)
             {
                 consumer.Subscribe(topicName);
-                var result = consumer.Consume(stoppingToken);
-                await new MessageReceivedEventHandler().Handle(result, _telemetryClient);
+                try
+                {
+                    Console.WriteLine($"Trying to consume events on topic '{topicName}'...");
+                    var result = consumer.Consume(stoppingToken);
+                    await new MessageReceivedEventHandler().Handle(result, _telemetryClient);
+
+                }
+                catch (Exception ex)
+                {
+                    _telemetryClient.TrackException(ex);
+                    Console.WriteLine($"Failed to consume events on topic '{topicName}': {ex.Message}");
+                    Thread.Sleep(10000);
+                }
             }
         }
     }

--- a/chapter07/producer/Dockerfile
+++ b/chapter07/producer/Dockerfile
@@ -1,6 +1,6 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
@@ -10,7 +10,7 @@ RUN echo "This is my base image" > /tmp/image_type
 FROM base as mydebug
 RUN echo "This is my debug image" > /tmp/image_type
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 WORKDIR /src
 COPY ["producer/producer.csproj", "producer/"]
 RUN dotnet restore "producer/producer.csproj"

--- a/chapter11/01 At-most-once/consumer/Dockerfile
+++ b/chapter11/01 At-most-once/consumer/Dockerfile
@@ -1,6 +1,6 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/runtime:6.0 AS base
+FROM mcr.microsoft.com/dotnet/runtime:7.0 AS base
 WORKDIR /app
 
 # <add commands here to modify both the debug and release container image>
@@ -9,7 +9,7 @@ RUN echo "This is my base image" > /tmp/image_type
 FROM base as mydebug
 RUN echo "This is my debug image" > /tmp/image_type
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 WORKDIR /src
 COPY ["consumer/consumer.csproj", "consumer/"]
 RUN dotnet restore "consumer/consumer.csproj"

--- a/chapter11/01 At-most-once/consumer/consumerService.cs
+++ b/chapter11/01 At-most-once/consumer/consumerService.cs
@@ -31,9 +31,19 @@ namespace consumer
             while (!stoppingToken.IsCancellationRequested)
             {
                 consumer.Subscribe(topicName);
-                var result = consumer.Consume(stoppingToken);
-                consumer.Commit(result);
-                await new MessageReceivedEventHandler().Handle(result, _telemetryClient);
+                try
+                {
+                    Console.WriteLine($"Trying to consume events on topic '{topicName}'...");
+                    var result = consumer.Consume(stoppingToken);
+                    consumer.Commit(result);
+                    await new MessageReceivedEventHandler().Handle(result, _telemetryClient);
+                }
+                catch (Exception ex)
+                {
+                    _telemetryClient.TrackException(ex);
+                    Console.WriteLine($"Failed to consume events on topic '{topicName}': {ex.Message}");
+                    Thread.Sleep(10000);
+                }
             }
         }
     }

--- a/chapter11/01 At-most-once/producer/Dockerfile
+++ b/chapter11/01 At-most-once/producer/Dockerfile
@@ -1,6 +1,6 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
@@ -10,7 +10,7 @@ RUN echo "This is my base image" > /tmp/image_type
 FROM base as mydebug
 RUN echo "This is my debug image" > /tmp/image_type
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 WORKDIR /src
 COPY ["producer/producer.csproj", "producer/"]
 RUN dotnet restore "producer/producer.csproj"

--- a/chapter11/02 At-least-once/consumer/Dockerfile
+++ b/chapter11/02 At-least-once/consumer/Dockerfile
@@ -1,6 +1,6 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/runtime:6.0 AS base
+FROM mcr.microsoft.com/dotnet/runtime:7.0 AS base
 WORKDIR /app
 
 # <add commands here to modify both the debug and release container image>
@@ -9,7 +9,7 @@ RUN echo "This is my base image" > /tmp/image_type
 FROM base as mydebug
 RUN echo "This is my debug image" > /tmp/image_type
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 WORKDIR /src
 COPY ["consumer/consumer.csproj", "consumer/"]
 RUN dotnet restore "consumer/consumer.csproj"

--- a/chapter11/02 At-least-once/consumer/consumerService.cs
+++ b/chapter11/02 At-least-once/consumer/consumerService.cs
@@ -31,9 +31,19 @@ namespace consumer
             while (!stoppingToken.IsCancellationRequested)
             {
                 consumer.Subscribe(topicName);
-                var result = consumer.Consume(stoppingToken);
-                await new MessageReceivedEventHandler().Handle(result, _telemetryClient);
-                consumer.Commit(result);
+                try
+                {
+                    Console.WriteLine($"Trying to consume events on topic '{topicName}'...");
+                    var result = consumer.Consume(stoppingToken);
+                    await new MessageReceivedEventHandler().Handle(result, _telemetryClient);
+                    consumer.Commit(result);
+                }
+                catch (Exception ex)
+                {
+                    _telemetryClient.TrackException(ex);
+                    Console.WriteLine($"Failed to consume events on topic '{topicName}': {ex.Message}");
+                    Thread.Sleep(10000);
+                }
             }
         }
     }

--- a/chapter11/02 At-least-once/producer/Dockerfile
+++ b/chapter11/02 At-least-once/producer/Dockerfile
@@ -1,6 +1,6 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
@@ -10,7 +10,7 @@ RUN echo "This is my base image" > /tmp/image_type
 FROM base as mydebug
 RUN echo "This is my debug image" > /tmp/image_type
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 WORKDIR /src
 COPY ["producer/producer.csproj", "producer/"]
 RUN dotnet restore "producer/producer.csproj"

--- a/chapter11/03 Exactly once/consumer/Dockerfile
+++ b/chapter11/03 Exactly once/consumer/Dockerfile
@@ -1,6 +1,6 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/runtime:6.0 AS base
+FROM mcr.microsoft.com/dotnet/runtime:7.0 AS base
 WORKDIR /app
 
 # <add commands here to modify both the debug and release container image>
@@ -9,7 +9,7 @@ RUN echo "This is my base image" > /tmp/image_type
 FROM base as mydebug
 RUN echo "This is my debug image" > /tmp/image_type
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 WORKDIR /src
 COPY ["consumer/consumer.csproj", "consumer/"]
 RUN dotnet restore "consumer/consumer.csproj"

--- a/chapter11/03 Exactly once/producer/Dockerfile
+++ b/chapter11/03 Exactly once/producer/Dockerfile
@@ -1,6 +1,6 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
@@ -10,7 +10,7 @@ RUN echo "This is my base image" > /tmp/image_type
 FROM base as mydebug
 RUN echo "This is my debug image" > /tmp/image_type
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 WORKDIR /src
 COPY ["producer/producer.csproj", "producer/"]
 RUN dotnet restore "producer/producer.csproj"

--- a/chapter14/consumer/Dockerfile
+++ b/chapter14/consumer/Dockerfile
@@ -1,6 +1,6 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/runtime:6.0 AS base
+FROM mcr.microsoft.com/dotnet/runtime:7.0 AS base
 WORKDIR /app
 
 # <add commands here to modify both the debug and release container image>
@@ -9,7 +9,7 @@ RUN echo "This is my base image" > /tmp/image_type
 FROM base as mydebug
 RUN echo "This is my debug image" > /tmp/image_type
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 WORKDIR /src
 COPY ["consumer/consumer.csproj", "consumer/"]
 RUN dotnet restore "consumer/consumer.csproj"

--- a/chapter14/producer/Dockerfile
+++ b/chapter14/producer/Dockerfile
@@ -1,6 +1,6 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
@@ -10,7 +10,7 @@ RUN echo "This is my base image" > /tmp/image_type
 FROM base as mydebug
 RUN echo "This is my debug image" > /tmp/image_type
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 WORKDIR /src
 COPY ["producer/producer.csproj", "producer/"]
 RUN dotnet restore "producer/producer.csproj"

--- a/src/MTAEDA.Identification/MTAEDA.Identification.Command.API/Dockerfile
+++ b/src/MTAEDA.Identification/MTAEDA.Identification.Command.API/Dockerfile
@@ -1,11 +1,11 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 WORKDIR /src
 COPY ["MTAEDA.Notification.Command.API/MTAEDA.Notification.Command.API.csproj", "MTAEDA.Notification.Command.API/"]
 RUN dotnet restore "MTAEDA.Notification.Command.API/MTAEDA.Notification.Command.API.csproj"

--- a/src/MTAEDA.Identification/MTAEDA.Identification.Query.API/Dockerfile
+++ b/src/MTAEDA.Identification/MTAEDA.Identification.Query.API/Dockerfile
@@ -1,11 +1,11 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 WORKDIR /src
 COPY ["MTAEDA.Notification.Query.API/MTAEDA.Notification.Query.API.csproj", "MTAEDA.Notification.Query.API/"]
 RUN dotnet restore "MTAEDA.Notification.Query.API/MTAEDA.Notification.Query.API.csproj"

--- a/src/MTAEDA.Maintenance/MTAEDA.Maintenance.API/Dockerfile
+++ b/src/MTAEDA.Maintenance/MTAEDA.Maintenance.API/Dockerfile
@@ -1,11 +1,11 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 WORKDIR /src
 COPY ["MTAEDA.Maintenance.API/MTAEDA.Maintenance.API.csproj", "MTAEDA.Maintenance.API/"]
 RUN dotnet restore "MTAEDA.Maintenance.API/MTAEDA.Maintenance.API.csproj"

--- a/src/MTAEDA.Maintenance/MTAEDA.Maintenance.Query.API/Dockerfile
+++ b/src/MTAEDA.Maintenance/MTAEDA.Maintenance.Query.API/Dockerfile
@@ -1,11 +1,11 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 WORKDIR /src
 COPY ["MTAEDA.Maintenance.Query.API/MTAEDA.Maintenance.Query.API.csproj", "MTAEDA.Maintenance.Query.API/"]
 RUN dotnet restore "MTAEDA.Maintenance.Query.API/MTAEDA.Maintenance.Query.API.csproj"

--- a/src/MTAEDA.Notification/MTAEDA.Notification.Command.API/Dockerfile
+++ b/src/MTAEDA.Notification/MTAEDA.Notification.Command.API/Dockerfile
@@ -1,11 +1,11 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 WORKDIR /src
 COPY ["MTAEDA.Notification.Command.API/MTAEDA.Notification.Command.API.csproj", "MTAEDA.Notification.Command.API/"]
 RUN dotnet restore "MTAEDA.Notification.Command.API/MTAEDA.Notification.Command.API.csproj"

--- a/src/MTAEDA.Notification/MTAEDA.Notification.Query.API/Dockerfile
+++ b/src/MTAEDA.Notification/MTAEDA.Notification.Query.API/Dockerfile
@@ -1,11 +1,11 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 WORKDIR /src
 COPY ["MTAEDA.Notification.Query.API/MTAEDA.Notification.Query.API.csproj", "MTAEDA.Notification.Query.API/"]
 RUN dotnet restore "MTAEDA.Notification.Query.API/MTAEDA.Notification.Query.API.csproj"

--- a/src/MTAEDA.Passenger/MTAEDA.Passenger.Command.API/Dockerfile
+++ b/src/MTAEDA.Passenger/MTAEDA.Passenger.Command.API/Dockerfile
@@ -1,11 +1,11 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 WORKDIR /src
 COPY ["MTAEDA.Passenger.Command.API/MTAEDA.Passenger.Command.API.csproj", "MTAEDA.Passenger.Command.API/"]
 RUN dotnet restore "MTAEDA.Passenger.Command.API/MTAEDA.Passenger.Command.API.csproj"

--- a/src/MTAEDA.Passenger/MTAEDA.Passenger.Query.API/Dockerfile
+++ b/src/MTAEDA.Passenger/MTAEDA.Passenger.Query.API/Dockerfile
@@ -1,11 +1,11 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 WORKDIR /src
 COPY ["MTAEDA.Passenger.Query.API/MTAEDA.Passenger.Query.API.csproj", "MTAEDA.Passenger.Query.API/"]
 RUN dotnet restore "MTAEDA.Passenger.Query.API/MTAEDA.Passenger.Query.API.csproj"

--- a/src/MTAEDA.Scheduling/MTAEDA.Scheduling.Command.API/Dockerfile
+++ b/src/MTAEDA.Scheduling/MTAEDA.Scheduling.Command.API/Dockerfile
@@ -1,11 +1,11 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 WORKDIR /src
 COPY ["MTAEDA.Notification.Command.API/MTAEDA.Notification.Command.API.csproj", "MTAEDA.Notification.Command.API/"]
 RUN dotnet restore "MTAEDA.Notification.Command.API/MTAEDA.Notification.Command.API.csproj"

--- a/src/MTAEDA.Scheduling/MTAEDA.Scheduling.Query.API/Dockerfile
+++ b/src/MTAEDA.Scheduling/MTAEDA.Scheduling.Query.API/Dockerfile
@@ -1,11 +1,11 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 WORKDIR /src
 COPY ["MTAEDA.Notification.Query.API/MTAEDA.Notification.Query.API.csproj", "MTAEDA.Notification.Query.API/"]
 RUN dotnet restore "MTAEDA.Notification.Query.API/MTAEDA.Notification.Query.API.csproj"

--- a/src/MTAEDA.Station/MTAEDA.Station.Command.API/Dockerfile
+++ b/src/MTAEDA.Station/MTAEDA.Station.Command.API/Dockerfile
@@ -1,11 +1,11 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 WORKDIR /src
 COPY ["MTAEDA.Notification.Command.API/MTAEDA.Notification.Command.API.csproj", "MTAEDA.Notification.Command.API/"]
 RUN dotnet restore "MTAEDA.Notification.Command.API/MTAEDA.Notification.Command.API.csproj"

--- a/src/MTAEDA.Station/MTAEDA.Station.Query.API/Dockerfile
+++ b/src/MTAEDA.Station/MTAEDA.Station.Query.API/Dockerfile
@@ -1,11 +1,11 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 WORKDIR /src
 COPY ["MTAEDA.Notification.Query.API/MTAEDA.Notification.Query.API.csproj", "MTAEDA.Notification.Query.API/"]
 RUN dotnet restore "MTAEDA.Notification.Query.API/MTAEDA.Notification.Query.API.csproj"


### PR DESCRIPTION
I updated dockerfile references to base images, and also added a fix for when a new Kafka cluster doesn't have any topics because the producer hasn't emitted anything. This was causing the consumer to crash when trying to subscribe to a topic that didn't yet exist.